### PR TITLE
Fix regex when counting and dropping in the same rule

### DIFF
--- a/pkg/nftables/nftables.go
+++ b/pkg/nftables/nftables.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	extract = *regexp.MustCompile(`(?s)counter packets (\d+) bytes (\d+) comment "(.*)"`)
+	extract = *regexp.MustCompile(`(?s)counter packets (\d+) bytes (\d+)[\s\w]*comment "(.*)"`)
 )
 
 // Counter contians the statistic values of a nftabless counter


### PR DESCRIPTION
We use `counter drop comment "blah"` in our rules.

Also is this enough for version bump? :) Our current Ansible deployment enrolls the assets from the tags and doesn't build the code itself which means this change won't be included.